### PR TITLE
quiet down tracing::instrument attrs

### DIFF
--- a/src/convert/read.rs
+++ b/src/convert/read.rs
@@ -35,7 +35,7 @@ pub struct Context<'r, 'data: 'r> {
     pub userstrings: &'r UserStringReader<'data>,
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn user_type(TypeDefOrRefOrSpec(token): TypeDefOrRefOrSpec, ctx: &Context) -> Result<UserType> {
     use TokenTarget::*;
     let idx = token.index - 1;
@@ -59,7 +59,7 @@ pub fn user_type(TypeDefOrRefOrSpec(token): TypeDefOrRefOrSpec, ctx: &Context) -
     .map_err(|e| DLLError::CLI(scroll::Error::Custom(e)))
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn custom_modifier(src: CustomMod, ctx: &Context) -> Result<CustomTypeModifier> {
     Ok(match src {
         CustomMod::Required(t) => CustomTypeModifier::Required(user_type(t, ctx)?),
@@ -67,7 +67,7 @@ pub fn custom_modifier(src: CustomMod, ctx: &Context) -> Result<CustomTypeModifi
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub(super) fn base_type_sig<T: TypeKind>(sig: Type, ctx: &Context) -> Result<BaseType<T>> {
     use Type::*;
 
@@ -133,7 +133,7 @@ pub(super) fn base_type_sig<T: TypeKind>(sig: Type, ctx: &Context) -> Result<Bas
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn type_idx<T: TypeKind>(idx: TypeDefOrRef, ctx: &Context) -> Result<T> {
     match idx {
         TypeDefOrRef::TypeDef(i) => {
@@ -169,7 +169,7 @@ pub fn type_idx<T: TypeKind>(idx: TypeDefOrRef, ctx: &Context) -> Result<T> {
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn idx_with_mod<T: TypeKind>(idx: TypeDefOrRef, ctx: &Context) -> Result<(Vec<CustomTypeModifier>, T)> {
     if let TypeDefOrRef::TypeSpec(i) = idx {
         let t_idx = i - 1;
@@ -193,7 +193,7 @@ pub fn idx_with_mod<T: TypeKind>(idx: TypeDefOrRef, ctx: &Context) -> Result<(Ve
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn type_source<T: TypeKind>(idx: TypeDefOrRef, ctx: &Context) -> Result<TypeSource<T>> {
     match type_idx::<T>(idx, ctx)?.into_base() {
         Some(BaseType::Type { source, .. }) => Ok(source),
@@ -202,7 +202,7 @@ pub fn type_source<T: TypeKind>(idx: TypeDefOrRef, ctx: &Context) -> Result<Type
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn parameter<T: TypeKind>(p: Param, ctx: &Context) -> Result<signature::Parameter<T>> {
     use signature::ParameterType::*;
 
@@ -222,7 +222,7 @@ pub fn parameter<T: TypeKind>(p: Param, ctx: &Context) -> Result<signature::Para
 
 macro_rules! def_method_sig {
     (fn $name:ident($type:ty) -> $sig:ident) => {
-        #[tracing::instrument]
+        #[tracing::instrument(level = "trace", skip_all)]
         pub fn $name<T: TypeKind>(sig: $type, ctx: &Context) -> Result<signature::$sig<T>> {
             use signature::*;
             {
@@ -258,7 +258,7 @@ macro_rules! def_method_sig {
 def_method_sig!(fn managed_method(MethodDefSig) -> ManagedMethod);
 def_method_sig!(fn maybe_unmanaged_method(StandAloneMethodSig) -> MaybeUnmanagedMethod);
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 
 pub fn type_token(tok: Token, ctx: &Context) -> Result<MethodType> {
     use TokenTarget::*;
@@ -279,7 +279,7 @@ pub struct MethodContext<'r> {
     pub method_map: &'r HashMap<usize, usize>,
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn user_method(idx: MethodDefOrRef, ctx: &MethodContext) -> Result<UserMethod> {
     Ok(match idx {
         MethodDefOrRef::MethodDef(i) => {
@@ -300,7 +300,7 @@ pub fn user_method(idx: MethodDefOrRef, ctx: &MethodContext) -> Result<UserMetho
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn user_method_token(tok: Token, ctx: &MethodContext) -> Result<UserMethod> {
     use TokenTarget::*;
     match tok.target {
@@ -310,7 +310,7 @@ fn user_method_token(tok: Token, ctx: &MethodContext) -> Result<UserMethod> {
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn method_source<'r>(tok: Token, ctx: &Context<'r, '_>, m_ctx: &MethodContext<'r>) -> Result<MethodSource> {
     use TokenTarget::*;
     Ok(match tok.target {
@@ -335,7 +335,7 @@ fn method_source<'r>(tok: Token, ctx: &Context<'r, '_>, m_ctx: &MethodContext<'r
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn field_source(tok: Token, ctx: &MethodContext) -> Result<FieldSource> {
     use TokenTarget::*;
     let idx = tok.index - 1;
@@ -352,7 +352,7 @@ fn field_source(tok: Token, ctx: &MethodContext) -> Result<FieldSource> {
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 #[allow(clippy::too_many_lines)]
 pub fn instruction<'r>(
     instruction: il::Instruction,

--- a/src/convert/write.rs
+++ b/src/convert/write.rs
@@ -39,7 +39,7 @@ pub struct Context<'a> {
     pub blob_scratch: &'a mut DynamicBuffer,
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn index(t: &impl TypeKind, ctx: &mut Context) -> Result<TypeDefOrRef> {
     let hash = crate::utils::hash(t);
 
@@ -54,7 +54,7 @@ pub fn index(t: &impl TypeKind, ctx: &mut Context) -> Result<TypeDefOrRef> {
     Ok(result)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn user_index(t: UserType) -> TypeDefOrRef {
     match t {
         UserType::Definition(d) => TypeDefOrRef::TypeDef(d.0 + 1),
@@ -62,7 +62,7 @@ pub fn user_index(t: UserType) -> TypeDefOrRef {
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn source_sig(value_kind: Option<ValueKind>, t: &TypeSource<impl TypeKind>, ctx: &mut Context) -> Result<SType> {
     let Some(value_kind) = value_kind else {
         return Err(DLLError::CLI(scroll::Error::Custom(
@@ -85,7 +85,7 @@ fn source_sig(value_kind: Option<ValueKind>, t: &TypeSource<impl TypeKind>, ctx:
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn source_index(
     value_kind: Option<ValueKind>,
     t: &TypeSource<impl TypeKind>,
@@ -98,7 +98,7 @@ pub fn source_index(
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn base_index(base: &BaseType<impl TypeKind>, ctx: &mut Context) -> Result<TypeDefOrRef> {
     Ok(match base {
         BaseType::Type { value_kind, source } => source_index(*value_kind, source, ctx)?,
@@ -106,7 +106,7 @@ pub fn base_index(base: &BaseType<impl TypeKind>, ctx: &mut Context) -> Result<T
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn into_blob(
     sig: impl TryIntoCtx<(), DynamicBuffer, Error = scroll::Error> + Debug,
     ctx: &mut Context,
@@ -118,7 +118,7 @@ pub fn into_blob(
     Ok(ctx.blobs.write(ctx.blob_scratch.get())?)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub(super) fn into_index(
     sig: impl TryIntoCtx<(), DynamicBuffer, Error = scroll::Error> + Debug,
     ctx: &mut Context,
@@ -133,7 +133,7 @@ pub(super) fn into_index(
     Ok(TypeDefOrRef::TypeSpec(len + 1))
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub(super) fn base_sig(base: &BaseType<impl TypeKind>, ctx: &mut Context) -> Result<SType> {
     use BaseType::*;
 
@@ -168,7 +168,7 @@ pub(super) fn base_sig(base: &BaseType<impl TypeKind>, ctx: &mut Context) -> Res
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn maybe_unmanaged_method<T: TypeKind>(
     sig: &MaybeUnmanagedMethod<T>,
     ctx: &mut Context,
@@ -192,7 +192,7 @@ fn maybe_unmanaged_method<T: TypeKind>(
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn custom_modifiers(mods: &[CustomTypeModifier]) -> Vec<CustomMod> {
     mods.iter()
         .map(|m| match m {
@@ -202,7 +202,7 @@ pub fn custom_modifiers(mods: &[CustomTypeModifier]) -> Vec<CustomMod> {
         .collect()
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn parameter_sig<T: TypeKind>(p: &Parameter<T>, ctx: &mut Context) -> Result<Param> {
     Ok(Param(
         custom_modifiers(&p.0),
@@ -218,7 +218,7 @@ fn parameter_sig<T: TypeKind>(p: &Parameter<T>, ctx: &mut Context) -> Result<Par
 //     into_blob(parameter_sig(p, ctx)?, ctx)
 // }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn ret_type_sig<T: TypeKind>(r: &ReturnType<T>, ctx: &mut Context) -> Result<RetType> {
     Ok(RetType(
         custom_modifiers(&r.0),
@@ -231,7 +231,7 @@ fn ret_type_sig<T: TypeKind>(r: &ReturnType<T>, ctx: &mut Context) -> Result<Ret
     ))
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn method_def_sig<T: TypeKind>(sig: &ManagedMethod<T>, ctx: &mut Context) -> Result<MethodDefSig> {
     Ok(MethodDefSig {
         has_this: sig.instance,
@@ -246,12 +246,12 @@ fn method_def_sig<T: TypeKind>(sig: &ManagedMethod<T>, ctx: &mut Context) -> Res
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn method_def<T: TypeKind>(sig: &ManagedMethod<T>, ctx: &mut Context) -> Result<Blob> {
     into_blob(method_def_sig(sig, ctx)?, ctx)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn method_ref_sig<T: TypeKind>(sig: &ManagedMethod<T>, ctx: &mut Context) -> Result<MethodRefSig> {
     Ok(MethodRefSig {
         method_def: method_def_sig(sig, ctx)?,
@@ -264,12 +264,12 @@ fn method_ref_sig<T: TypeKind>(sig: &ManagedMethod<T>, ctx: &mut Context) -> Res
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn method_ref<T: TypeKind>(sig: &ManagedMethod<T>, ctx: &mut Context) -> Result<Blob> {
     into_blob(method_ref_sig(sig, ctx)?, ctx)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn field_sig(f: &Field, ctx: &mut Context) -> Result<FieldSig> {
     Ok(FieldSig {
         custom_modifiers: custom_modifiers(&f.type_modifiers),
@@ -278,12 +278,12 @@ fn field_sig(f: &Field, ctx: &mut Context) -> Result<FieldSig> {
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn field_def(f: &Field, ctx: &mut Context) -> Result<Blob> {
     into_blob(field_sig(f, ctx)?, ctx)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn field_ref_sig(f: &ExternalFieldReference, ctx: &mut Context) -> Result<FieldSig> {
     Ok(FieldSig {
         custom_modifiers: custom_modifiers(&f.custom_modifiers),
@@ -292,12 +292,12 @@ fn field_ref_sig(f: &ExternalFieldReference, ctx: &mut Context) -> Result<FieldS
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn field_ref(f: &ExternalFieldReference, ctx: &mut Context) -> Result<Blob> {
     into_blob(field_ref_sig(f, ctx)?, ctx)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn property_sig(p: &Property, ctx: &mut Context) -> Result<PropertySig> {
     Ok(PropertySig {
         has_this: !p.static_member,
@@ -310,12 +310,12 @@ fn property_sig(p: &Property, ctx: &mut Context) -> Result<PropertySig> {
     })
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn property(p: &Property, ctx: &mut Context) -> Result<Blob> {
     into_blob(property_sig(p, ctx)?, ctx)
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn idx_with_modifiers(t: &impl TypeKind, mods: &[CustomTypeModifier], ctx: &mut Context) -> Result<TypeDefOrRef> {
     if let Some(BaseType::Type {
         source: TypeSource::User(u),
@@ -348,7 +348,7 @@ pub fn idx_with_modifiers(t: &impl TypeKind, mods: &[CustomTypeModifier], ctx: &
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 fn local_var_sig(vars: &[LocalVariable], ctx: &mut Context) -> Result<LocalVarSig> {
     Ok(LocalVarSig(
         vars.iter()
@@ -372,7 +372,7 @@ fn local_var_sig(vars: &[LocalVariable], ctx: &mut Context) -> Result<LocalVarSi
     ))
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn local_vars(vars: &[LocalVariable], ctx: &mut Context) -> Result<Blob> {
     into_blob(local_var_sig(vars, ctx)?, ctx)
 }
@@ -385,7 +385,7 @@ pub struct MethodContext<'a, T, U> {
     pub field_source: &'a U,
 }
 
-#[tracing::instrument(skip(m_ctx))]
+#[tracing::instrument(level = "trace", skip_all)]
 #[allow(clippy::too_many_lines)]
 pub fn instruction(
     instruction: &Instruction,


### PR DESCRIPTION
The bare `#[tracing::instrument]` macro captures every fn argument as a span field by Debug.
For fields like `ctx: &Context` this emits megabytes of debug logs.

Switching to `#[tracing::instrument(level = "trace", skip_all)]` makes the library massively faster for me, when tracing is enabled.

